### PR TITLE
bug: use (current - start), not (target - current) in transition

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,7 +41,7 @@ class App extends Component {
         const updateStateFn = () => {
             const currentDate = new Date();
             if (currentDate < targetDate) {
-                const t = (targetDate.getTime() - currentDate.getTime()) / transitionDuration;
+                const t = (currentDate.getTime() - startDate.getTime()) / transitionDuration;
                 this.setState({
                     sett: transitionFn(ease(t)).toString()
                 });


### PR DESCRIPTION
- using (target - current) caused transition to go from end
and move to start, rather than go from start to end